### PR TITLE
Use TLS for `CheckInternetConnection()`

### DIFF
--- a/src/WaterLevel.js
+++ b/src/WaterLevel.js
@@ -537,7 +537,7 @@ function getTrend(trend) {
 
 //#region internet request functions
 async function CheckInternetConnection() {
-  result = await getRequest("http://pegelonline.wsv.de");
+  result = await getRequest("https://pegelonline.wsv.de");
   if (result == false) {
     drawError(translation.noInternetConnection);
     return false;


### PR DESCRIPTION
For some reason the widget stopped working for me and moving from http to https for `CheckInternetConnection()` fixed my widget.